### PR TITLE
new-ctf signed bit offsets fix

### DIFF
--- a/usr/src/Makefile.master
+++ b/usr/src/Makefile.master
@@ -918,8 +918,8 @@ CTFMRGFLAGS=
 # honor them.
 #
 ENABLE_NEW_CTF=$(POUND_SIGN)
-$(ENABLE_NEW_CTF)$(_GNUC)CTFCONVERT=	$(ONBLD_TOOLS)/bin/$(MACH)/ctfconvert-altexec
-$(ENABLE_NEW_CTF)$(_GNUC)CTFMERGE=	$(ONBLD_TOOLS)/bin/$(MACH)/ctfmerge-altexec
+$(ENABLE_NEW_CTF)$(__GNUC)CTFCONVERT=	$(ONBLD_TOOLS)/bin/$(MACH)/ctfconvert-altexec
+$(ENABLE_NEW_CTF)$(__GNUC)CTFMERGE=	$(ONBLD_TOOLS)/bin/$(MACH)/ctfmerge-altexec
 
 CTFCONVERT_O		= $(CTFCONVERT) $(CTFCVTFLAGS) $@
 

--- a/usr/src/lib/libctf/common/ctf_dwarf.c
+++ b/usr/src/lib/libctf/common/ctf_dwarf.c
@@ -1027,7 +1027,8 @@ ctf_dwarf_member_offset(ctf_die_t *cdp, Dwarf_Die die, ctf_id_t mid,
     ulong_t *offp)
 {
 	int ret;
-	Dwarf_Unsigned loc, bitsz, bytesz, bitoff;
+	Dwarf_Unsigned loc, bitsz, bytesz;
+	Dwarf_Signed bitoff;
 	size_t off;
 	ssize_t tsz;
 
@@ -1043,7 +1044,7 @@ ctf_dwarf_member_offset(ctf_die_t *cdp, Dwarf_Die die, ctf_id_t mid,
 		return (ret);
 	off = loc * 8;
 
-	if ((ret = ctf_dwarf_unsigned(cdp, die, DW_AT_bit_offset,
+	if ((ret = ctf_dwarf_signed(cdp, die, DW_AT_bit_offset,
 	    &bitoff)) != 0) {
 		if (ret != ENOENT)
 			return (ret);

--- a/usr/src/tools/make/lib/bsd/Makefile
+++ b/usr/src/tools/make/lib/bsd/Makefile
@@ -28,4 +28,8 @@ install: all
 
 lint:
 
+# We can't create CTF in the tools build because of a bootstrap bug with the new CTF
+$(DYNLIB) := CTFMERGE_POST= :
+CTFCONVERT_O= :
+
 include $(SRC)/lib/Makefile.targ

--- a/usr/src/tools/make/lib/makestate/Makefile.com
+++ b/usr/src/tools/make/lib/makestate/Makefile.com
@@ -37,4 +37,8 @@ $(ROOTONBLDLIBMACH)/%: %
 $(ROOTONBLDLIBMACH64)/%: %
 	$(INS.file)
 
+# We can't create CTF in the tools build because of a bootstrap bug with the new CTF
+$(DYNLIB) := CTFMERGE_POST= :
+CTFCONVERT_O= :
+
 include $(SRC)/lib/Makefile.targ

--- a/usr/src/tools/make/lib/mksh/Makefile
+++ b/usr/src/tools/make/lib/mksh/Makefile
@@ -29,4 +29,8 @@ install: all
 
 lint:
 
+# We can't create CTF in the tools build because of a bootstrap bug with the new CTF
+$(DYNLIB) := CTFMERGE_POST= :
+CTFCONVERT_O= :
+
 include $(SRC)/lib/Makefile.targ

--- a/usr/src/tools/make/lib/vroot/Makefile
+++ b/usr/src/tools/make/lib/vroot/Makefile
@@ -50,4 +50,8 @@ install: all
 
 lint:
 
+# We can't create CTF in the tools build because of a bootstrap bug with the new CTF
+$(DYNLIB) := CTFMERGE_POST= :
+CTFCONVERT_O= :
+
 include $(SRC)/lib/Makefile.targ

--- a/usr/src/uts/Makefile.uts
+++ b/usr/src/uts/Makefile.uts
@@ -636,4 +636,4 @@ USBDEVS_DATA =	$(SRC)/uts/common/io/usb/usbdevs
 # are building with the private -X option to ctfconvert which allows us
 # to fixup the struct cpu to account for machcpu.
 #
-$(ENABLE_NEW_CTF)$(_GNUC)CTFCVTFLAGS += -X
+$(ENABLE_NEW_CTF)$(__GNUC)CTFCVTFLAGS += -X


### PR DESCRIPTION
In certain cases which are hard to fathom (I'm going to file a GCC-bug, too, to see what they think), GCC will emit negative bit offsets for bitfield types.  This causes us to deal with the basic sense that we don't choke.
